### PR TITLE
Check whether symbolic links reference directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var Plugin = require('broccoli-caching-writer');
 var shell = require('shelljs');
+var fs = require('fs');
 
 require('colors').setTheme({
   info: 'grey',
@@ -24,8 +25,13 @@ function ScssLinter(inputNodes, options) {
 ScssLinter.prototype.build = function() {
   var options = this.options;
   this.inputPaths.forEach(function(inputPath) {
+    if (fs.statSync(inputPath).isDirectory() && inputPath.slice(-1) !== '/') {
+      inputPath += '/';
+    }
+
     var result = shell.exec(buildCommand(inputPath, options), {silent: true});
     console.log(formatOutput(result.stdout, inputPath));
+
     if (result.code === 2) {
       throw new Error('There are errors in your SCSS files');
     }


### PR DESCRIPTION
After trying this addon in [ember-cli-scss-lint](https://github.com/tomasbasham/ember-cli-scss-lint) I was unable to get any output where there were SCSS files containing linting errors. Some digging made it clear that the paths ember-cli was passing to the addon were symbolic links to the styles directory. Apparently `scss-lint` doesn't play too nicely with symbolic links.

This PR adds the following:
- Checks the type of inputPath. We're expecting either a file or a directory here,
- If it is a directory, makes sure it ends with a trailing slash. This is what was causing problems with ember-cli
